### PR TITLE
Make 'conference' at <hostname> resolve

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,9 @@ services:
         ipv4_address: 172.50.0.10
     extra_hosts:
       - "xmpp1.localhost.example:172.50.0.10"
+      - "conference.xmpp1.localhost.example:172.50.0.10"
       - "xmpp2.localhost.example:172.50.0.20"
+      - "conference.xmpp2.localhost.example:172.50.0.20"
 
   xmpp2:
     image: openfire:fmuc
@@ -56,7 +58,9 @@ services:
         ipv4_address: 172.50.0.20
     extra_hosts:
       - "xmpp1.localhost.example:172.50.0.10"
+      - "conference.xmpp1.localhost.example:172.50.0.10"
       - "xmpp2.localhost.example:172.50.0.20"
+      - "conference.xmpp2.localhost.example:172.50.0.20"
  
 networks:
   net-one:


### PR DESCRIPTION
This helps when federation between domains is first established based on MUC traffic. Without this, federation must have established through other means.