### PR TITLE
Fix ofid table to prevent PK collisions

### DIFF
--- a/sql/clustered/1/openfire.sql
+++ b/sql/clustered/1/openfire.sql
@@ -610,7 +610,7 @@ COPY public.ofgroupuser (groupname, username, administrator) FROM stdin;
 --
 
 COPY public.ofid (idtype, id) FROM stdin;
-18	1
+18	11
 19	1
 26	2
 23	6


### PR DESCRIPTION
An oversight on #24. When adding stuff to tables that get their PK from `public.ofid`, this change needs keeping, else Openfire will attempt to overwrite it.

Found when Smack's MoodIntegrationTest failed with an InternalServerError and a Primary Key violation on Openfire.