### PR TITLE
Add support for specifying openfire tags via env or parameter

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+OPENFIRE_TAG=latest

--- a/docker-compose-clustered.yml
+++ b/docker-compose-clustered.yml
@@ -29,7 +29,7 @@ services:
         ipv4_address: 172.60.0.99
   
   xmpp1:
-    image: openfire:latest
+    image: "openfire:${OPENFIRE_TAG}"
     ports:
       - "5221:5222"
       - "5261:5269"
@@ -53,7 +53,7 @@ services:
       - "conference.xmpp2.localhost.example:172.50.0.20"
 
   xmpp2:
-    image: openfire:latest
+    image: "openfire:${OPENFIRE_TAG}"
     ports:
       - "5222:5222"
       - "5262:5269"

--- a/docker-compose-federated.yml
+++ b/docker-compose-federated.yml
@@ -31,7 +31,7 @@ services:
         ipv4_address: 172.50.0.21
 
   xmpp1:
-    image: openfire:latest
+    image: "openfire:${OPENFIRE_TAG}"
     ports:
       - "5221:5222"
       - "5261:5269"
@@ -54,7 +54,7 @@ services:
       - "conference.xmpp2.localhost.example:172.50.0.20"
 
   xmpp2:
-    image: openfire:latest
+    image: "openfire:${OPENFIRE_TAG}"
     ports:
       - "5222:5222"
       - "5262:5269"

--- a/start.sh
+++ b/start.sh
@@ -5,6 +5,7 @@ COMPOSE_FILE=docker-compose-federated.yml
 if [ "$1" = "-c" ]; then
   echo "Starting a clustered environment."
   COMPOSE_FILE=docker-compose-clustered.yml
+  shift
 else
   echo "Starting a federated environment (use -c to start a clustered environment instead)."
 fi
@@ -17,4 +18,8 @@ rm -rf _data
 mkdir _data
 cp -r xmpp _data/
 
+if [ -n "$1" ]; then
+  echo "Using Openfire tag: $1"
+  export OPENFIRE_TAG=$1
+fi
 docker-compose -f $COMPOSE_FILE up


### PR DESCRIPTION
Adding a .env containing "OPENFIRE_TAG=461" or running `./start.sh 461` will get openfire:461 rather than latest