### PR TITLE
Fix copy pasta in getopts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _data
 .idea
 *.iml
+.DS_Store

--- a/start.sh
+++ b/start.sh
@@ -21,8 +21,12 @@ while getopts con:h o; do
         OTHER_DOMAIN=true
         ;;
     n)
-        echo "Using Openfire tag: $1"
-        export OPENFIRE_TAG=$1
+        if [[ $OPTARG =~ " " ]]; then
+          echo "Docker tags cannot contain spaces"
+          exit 1
+        fi
+        echo "Using Openfire tag: $OPTARG"
+        export OPENFIRE_TAG="$OPTARG"
         ;;
     h)  
         usage


### PR DESCRIPTION
When migrating to getopts, missed a $1 that should've been a $OPTARG.

Also:
* Added a defence against providing a docker tag containing spaces
* Updated gitignore to include MacOS plague files.