### PR TITLE
Load balance connections from other domain over s2s via nginx

### DIFF
--- a/docker-compose-otherdomain.yml
+++ b/docker-compose-otherdomain.yml
@@ -35,12 +35,8 @@ services:
       openfire-clustered-net:
         ipv4_address: 172.60.0.110
     extra_hosts:
-      - "xmpp.localhost.example:172.60.0.10"
-      - "xmpp.localhost.example:172.60.0.20"
-      - "xmpp.localhost.example:172.60.0.30"
-      - "conference.xmpp.localhost.example:172.60.0.10"
-      - "conference.xmpp.localhost.example:172.60.0.20"
-      - "conference.xmpp.localhost.example:172.60.0.30"
+      - "xmpp.localhost.example:172.60.0.99"
+      - "conference.xmpp.localhost.example:172.60.0.99"
       - "otherxmpp.localhost.example:172.60.0.110"
       - "conference.otherxmpp.localhost.example:172.60.0.110"
   

--- a/nginx/clustered/nginx.conf
+++ b/nginx/clustered/nginx.conf
@@ -39,6 +39,32 @@ stream {
         proxy_timeout 30s;
         proxy_pass boshs;
     }
+
+    upstream s2s {
+        server 172.60.0.10:5269;
+        server 172.60.0.20:5269;
+        server 172.60.0.30:5269;
+    }
+    server {
+        listen 5269;
+        tcp_nodelay on;
+        proxy_connect_timeout 10s; 
+        proxy_timeout 1m;
+        proxy_pass s2s;
+    }
+
+    upstream s2slegacy {
+        server 172.60.0.10:5270;
+        server 172.60.0.20:5270;
+        server 172.60.0.30:5270;
+    }
+    server {
+        listen 5270;
+        tcp_nodelay on;
+        proxy_connect_timeout 10s; 
+        proxy_timeout 1m;
+        proxy_pass s2slegacy;
+    }
 }
 
 events {}


### PR DESCRIPTION
Prevents otherxmpp always preferring a connection to node 3 in the cluster.

My testing shows clients from both sides being able to initiate and connect to a MUC on the other side of the s2s connection, although I'm certain that the timings and strategy might want tuning for anything production-like (and perhaps even for testing environments if we hit issues)