### PR TITLE
Remove debug logging flag in database

### DIFF
--- a/sql/clustered/openfire.sql
+++ b/sql/clustered/openfire.sql
@@ -722,7 +722,6 @@ provider.vcard.className	org.jivesoftware.openfire.vcard.DefaultVCardProvider	0	
 provider.securityAudit.className	org.jivesoftware.openfire.security.DefaultSecurityAuditProvider	0	\N
 provider.user.className	org.jivesoftware.openfire.user.DefaultUserProvider	0	\N
 passwordKey	YJ1nKWyrMeGvTKu	0	\N
-log.debug.enabled	true	0	\N
 update.lastCheck	1605956807055	0	\N
 \.
 

--- a/sql/otherdomain/openfire.sql
+++ b/sql/otherdomain/openfire.sql
@@ -722,7 +722,6 @@ provider.vcard.className	org.jivesoftware.openfire.vcard.DefaultVCardProvider	0	
 provider.securityAudit.className	org.jivesoftware.openfire.security.DefaultSecurityAuditProvider	0	\N
 provider.user.className	org.jivesoftware.openfire.user.DefaultUserProvider	0	\N
 passwordKey	YJ1nKWyrMeGvTKu	0	\N
-log.debug.enabled	true	0	\N
 update.lastCheck	1605956807055	0	\N
 \.
 


### PR DESCRIPTION
By setting the 'debug' flag in the database, Openfire will, at boot time, override the configuration in log4j2.xml.

When debug logging is desired, it's best to configure that in the log4j2.xml file instead of in the database.