### PR TITLE
Update log file locations

### DIFF
--- a/scripts/get_logs.sh
+++ b/scripts/get_logs.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
-docker exec -t openfire-docker-compose_xmpp1_1 cat /usr/local/openfire/logs/all.log > 1-all.log
-docker exec -t openfire-docker-compose_xmpp2_1 cat /usr/local/openfire/logs/all.log > 2-all.log
-docker exec -t openfire-docker-compose_xmpp3_1 cat /usr/local/openfire/logs/all.log > 3-all.log
-docker exec -t openfire-docker-compose_xmpp2_1 cat /usr/local/openfire/logs/jive.audit-20210202-000.log > 2-jiveaudit.log
-docker exec -t openfire-docker-compose_otherxmpp_1 cat /usr/local/openfire/logs/all.log > other-all.log
+docker exec -t openfire-docker-compose_xmpp1_1 cat /usr/local/openfire/logs/openfire.log > 1-openfire.log
+docker exec -t openfire-docker-compose_xmpp2_1 cat /usr/local/openfire/logs/openfire.log > 2-openfire.log
+docker exec -t openfire-docker-compose_xmpp3_1 cat /usr/local/openfire/logs/openfire.log > 3-openfire.log
+docker exec -t openfire-docker-compose_otherxmpp_1 cat /usr/local/openfire/logs/openfire.log > other-openfire.log
 
 #docker cp openfire-docker-compose_xmpp1_1:/usr/local/openfire/logs/all.log 1all.log
 #docker cp openfire-docker-compose_xmpp2_1:/usr/local/openfire/logs/all.log 2all.log


### PR DESCRIPTION
Openfire 4.7.0 brings a change to the name of the log files. They've been renamed from 'all.log' to 'openfire.log'.

This commit applies the same change to this project.