### PR TITLE
Add optional logging container, run compose in background

### DIFF
--- a/docker-compose-logging.yml
+++ b/docker-compose-logging.yml
@@ -1,0 +1,11 @@
+version: '3.7'
+
+services:
+
+  dozzle:
+    container_name: dozzle
+    image: amir20/dozzle:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+      - 9999:8080

--- a/start.sh
+++ b/start.sh
@@ -1,24 +1,29 @@
 #!/bin/bash
 
-usage() { echo "Usage: $0 [-c] [-o] [-n openfire-tag] [-h]
+usage() { echo "Usage: $0 [-c] [-o] [-l] [-n openfire-tag] [-h]
 
   -c               Launches a Cluster instead of a FMUC stack
   -o               Launches another separate domain alongside the cluster
+  -l               Launches a Dozzle container to collect logs
   -n openfire-tag  Launches all Openfire instances with the specified tag. This overrides the value in .env
   -h               Show this helpful information
 "; exit 0; }
 
 CLUSTER_MODE=false
 OTHER_DOMAIN=false
+DOZZLE=false
 COMPOSE_FILE_COMMAND=("docker-compose")
 
-while getopts con:h o; do
+while getopts coln:h o; do
   case "$o" in
     c)
         CLUSTER_MODE=true
         ;;
     o)
         OTHER_DOMAIN=true
+        ;;
+    l)
+        DOZZLE=true
         ;;
     n)
         if [[ $OPTARG =~ " " ]]; then
@@ -53,6 +58,10 @@ case $CLUSTER_MODE in
            COMPOSE_FILE_COMMAND+=("-f" "docker-compose-federated.yml");;
 esac
 
+if [ $DOZZLE == "true" ]; then
+  COMPOSE_FILE_COMMAND+=("-f" "docker-compose-logging.yml")
+fi
+
 "${COMPOSE_FILE_COMMAND[@]}" down
 "${COMPOSE_FILE_COMMAND[@]}" pull
 
@@ -64,4 +73,4 @@ cp -r plugins_for_clustered _data/
 cp -r plugins_for_federated _data/
 cp -r plugins_for_other _data/
 
-"${COMPOSE_FILE_COMMAND[@]}" up
+"${COMPOSE_FILE_COMMAND[@]}" up -d

--- a/stop.sh
+++ b/stop.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# A list of all possible docker compose files that might've been used to start the stack
+
+docker-compose \
+ -f docker-compose-clustered.yml \
+ -f docker-compose-federated.yml \
+ -f docker-compose-otherdomain.yml \
+ -f docker-compose-logging.yml \
+down


### PR DESCRIPTION
* Add a dozzle container to view container level logs together in a lightweight UI
* Alter running to go to the background rather than run in the console