### PR TITLE
Add sudo for deleting _data on Linux

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
-usage() { echo "Usage: $0 [-c] [-o] [-l] [-n openfire-tag] [-h]
+usage() { echo "Usage: $0 [-c] [-o] [-l] [-f] [-n openfire-tag] [-h]
 
   -c               Launches a Cluster instead of a FMUC stack
   -o               Launches another separate domain alongside the cluster
   -l               Launches a Dozzle container to collect logs
+  -f               Ignore errors, like file cleanups. Don't pause for the user, and just keep going.
   -n openfire-tag  Launches all Openfire instances with the specified tag. This overrides the value in .env
   -h               Show this helpful information
 "; exit 0; }
@@ -13,8 +14,9 @@ CLUSTER_MODE=false
 OTHER_DOMAIN=false
 DOZZLE=false
 COMPOSE_FILE_COMMAND=("docker-compose")
+NO_SUDO=false
 
-while getopts coln:h o; do
+while getopts colfn:h o; do
   case "$o" in
     c)
         CLUSTER_MODE=true
@@ -24,6 +26,9 @@ while getopts coln:h o; do
         ;;
     l)
         DOZZLE=true
+        ;;
+    f)
+        NO_SUDO=true
         ;;
     n)
         if [[ $OPTARG =~ " " ]]; then
@@ -66,7 +71,15 @@ fi
 "${COMPOSE_FILE_COMMAND[@]}" pull
 
 # Clean up temporary persistence data
-rm -rf _data
+sudo_for_cleanup() {
+  echo "Couldn't clean up the _data directory, probably due to permissions on files that a container created"
+  if [ $NO_SUDO == "false" ]; then
+    echo "Trying sudo to tidy it up"
+    sudo rm -rf _data
+  fi
+}
+
+rm -rf _data || sudo_for_cleanup
 mkdir _data
 cp -r xmpp _data/
 cp -r plugins_for_clustered _data/


### PR DESCRIPTION
Fixes #18

If cleanup fails, uses sudo to nuke it.
Adds an option to never prompt for sudo, in case people prefer their scripts to never prompt for user input.