### PR TITLE
Add support for HTTP File Upload (cluster-only)

### DIFF
--- a/cluster/docker-compose-clustered.yml
+++ b/cluster/docker-compose-clustered.yml
@@ -42,6 +42,7 @@ services:
       - ./_data/xmpp/1/conf:/var/lib/openfire/conf
       - ./_data/plugins:/opt/plugins
       - ../_common/wait-for-it.sh:/wait-for-it.sh
+      - ./_data/shared-httpfileupload-repo:/mnt/shared-httpfileupload-repo
     command: ["/wait-for-it.sh", "-s", "db:5432", "--", "/sbin/entrypoint.sh"]
     networks:
       openfire-clustered-net:
@@ -68,6 +69,7 @@ services:
       - ./_data/xmpp/2/conf:/var/lib/openfire/conf
       - ./_data/plugins:/opt/plugins
       - ../_common/wait-for-it.sh:/wait-for-it.sh
+      - ./_data/shared-httpfileupload-repo:/mnt/shared-httpfileupload-repo
     command: ["/wait-for-it.sh", "-s", "db:5432", "--", "/sbin/entrypoint.sh"]
     networks:
       openfire-clustered-net:
@@ -94,6 +96,7 @@ services:
       - ./_data/xmpp/3/conf:/var/lib/openfire/conf
       - ./_data/plugins:/opt/plugins
       - ../_common/wait-for-it.sh:/wait-for-it.sh
+      - ./_data/shared-httpfileupload-repo:/mnt/shared-httpfileupload-repo
     command: ["/wait-for-it.sh", "-s", "db:5432", "--", "/sbin/entrypoint.sh"]
     networks:
       openfire-clustered-net:

--- a/cluster/sql/openfire.sql
+++ b/cluster/sql/openfire.sql
@@ -723,6 +723,9 @@ provider.securityAudit.className	org.jivesoftware.openfire.security.DefaultSecur
 provider.user.className	org.jivesoftware.openfire.user.DefaultUserProvider	0	\N
 passwordKey	YJ1nKWyrMeGvTKu	0	\N
 update.lastCheck	1605956807055	0	\N
+plugin.httpfileupload.fileRepo	/mnt/shared-httpfileupload-repo	0	\N
+plugin.httpfileupload.announcedWebPort	57070	0	\N
+plugin.httpfileupload.announcedWebProtocol	http	0	\N
 \.
 
 

--- a/cluster/start.sh
+++ b/cluster/start.sh
@@ -51,6 +51,8 @@ fi
 mkdir _data
 cp -r xmpp _data/
 cp -r plugins _data/
+mkdir _data/shared-httpfileupload-repo
+chmod 777 _data/shared-httpfileupload-repo
 
 "${COMPOSE_FILE_COMMAND[@]}" up -d || popd
 popd


### PR DESCRIPTION
This adds a docker volume to each server, configures each Openfire to use that volume as the backend storage for HTTP File Upload, and configures Openfire to use an endpoint _on the load balancer_ as the endpoint for all HTTP file upload web-interaction.

Note that the httpfileupload plugin is not added in this commit (as its implementation is still being worked on).

I've created this as a draft PR for now, as:

- the Openfire plugin needs to be added
- support needs to be added to `cluster_with_federation` and `federation` environments.