### PR TITLE
[chore] Remove obsolete version attribute from docker-compose yml files

### DIFF
--- a/cluster/docker-compose-clustered.yml
+++ b/cluster/docker-compose-clustered.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
 
   db:

--- a/cluster_with_federation/docker-compose-clustered.yml
+++ b/cluster_with_federation/docker-compose-clustered.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
 
   db:

--- a/proxy/docker-compose.yml
+++ b/proxy/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
 
   db:

--- a/simple/docker-compose.yml
+++ b/simple/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
 
   db:


### PR DESCRIPTION
Fixes warnings like these:
```
WARN[0000] openfire-docker-compose/cluster/docker-compose-clustered.yml: `version` is obsolete
```