### PR TITLE
chore: Update java.security with new from Openfire

### DIFF
--- a/federation/xmpp/1/conf/security/java.security
+++ b/federation/xmpp/1/conf/security/java.security
@@ -1,2 +1,5 @@
 # Enable client-driven OCSP
 ocsp.enable=true
+
+# Enable CRL Distribution Points extension in certificates (download CRL from URL in certificate)
+org.bouncycastle.x509.enableCRLDP=true

--- a/federation/xmpp/2/conf/security/java.security
+++ b/federation/xmpp/2/conf/security/java.security
@@ -1,2 +1,5 @@
 # Enable client-driven OCSP
 ocsp.enable=true
+
+# Enable CRL Distribution Points extension in certificates (download CRL from URL in certificate)
+org.bouncycastle.x509.enableCRLDP=true


### PR DESCRIPTION
This file has been updated in Openfire to enable CRL downloading, so I'm porting it into this project as we use a copy of the security directory and overwrite the original.