### PR TITLE
Prevent docker-compose from pulling openfire image from registry

### DIFF
--- a/cluster/docker-compose-clustered.yml
+++ b/cluster/docker-compose-clustered.yml
@@ -22,6 +22,7 @@ services:
 
   xmpp1:
     image: "${OPENFIRE_IMAGE}:${OPENFIRE_TAG}"
+    pull_policy: never
     ports:
       - "5221:5222"
       - "5261:5269"
@@ -42,6 +43,7 @@ services:
 
   xmpp2:
     image: "${OPENFIRE_IMAGE}:${OPENFIRE_TAG}"
+    pull_policy: never
     ports:
       - "5222:5222"
       - "5262:5269"
@@ -62,6 +64,7 @@ services:
 
   xmpp3:
     image: "${OPENFIRE_IMAGE}:${OPENFIRE_TAG}"
+    pull_policy: never
     ports:
       - "5223:5222"
       - "5263:5269"

--- a/cluster_mssql/docker-compose-clustered.yml
+++ b/cluster_mssql/docker-compose-clustered.yml
@@ -47,6 +47,7 @@ services:
 
   xmpp1:
     image: "${OPENFIRE_IMAGE}:${OPENFIRE_TAG}"
+    pull_policy: never
     ports:
       - "5221:5222"
       - "5261:5269"
@@ -63,6 +64,7 @@ services:
 
   xmpp2:
     image: "${OPENFIRE_IMAGE}:${OPENFIRE_TAG}"
+    pull_policy: never
     ports:
       - "5222:5222"
       - "5262:5269"
@@ -79,6 +81,7 @@ services:
 
   xmpp3:
     image: "${OPENFIRE_IMAGE}:${OPENFIRE_TAG}"
+    pull_policy: never
     ports:
       - "5223:5222"
       - "5263:5269"

--- a/cluster_with_federation/docker-compose-clustered.yml
+++ b/cluster_with_federation/docker-compose-clustered.yml
@@ -22,6 +22,7 @@ services:
 
   xmpp1:
     image: "${OPENFIRE_IMAGE}:${OPENFIRE_TAG}"
+    pull_policy: never
     ports:
       - "5221:5222"
       - "5261:5269"
@@ -42,6 +43,7 @@ services:
 
   xmpp2:
     image: "${OPENFIRE_IMAGE}:${OPENFIRE_TAG}"
+    pull_policy: never
     ports:
       - "5222:5222"
       - "5262:5269"
@@ -62,6 +64,7 @@ services:
 
   xmpp3:
     image: "${OPENFIRE_IMAGE}:${OPENFIRE_TAG}"
+    pull_policy: never
     ports:
       - "5223:5222"
       - "5263:5269"
@@ -93,6 +96,7 @@ services:
 
   otherxmpp:
     image: "${OPENFIRE_IMAGE}:${OPENFIRE_TAG}"
+    pull_policy: never
     ports:
       - "5229:5222"
       - "5269:5269"

--- a/federation/docker-compose-federated.yml
+++ b/federation/docker-compose-federated.yml
@@ -24,6 +24,7 @@ services:
 
   xmpp1:
     image: "${OPENFIRE_IMAGE}:${OPENFIRE_TAG}"
+    pull_policy: never
     ports:
       - "5221:5222"
       - "5261:5269"
@@ -44,6 +45,7 @@ services:
 
   xmpp2:
     image: "${OPENFIRE_IMAGE}:${OPENFIRE_TAG}"
+    pull_policy: never
     ports:
       - "5222:5222"
       - "5262:5269"

--- a/proxy/docker-compose.yml
+++ b/proxy/docker-compose.yml
@@ -25,6 +25,7 @@ services:
   
   xmpp:
     image: "${OPENFIRE_IMAGE}:${OPENFIRE_TAG}"
+    pull_policy: never
     ports:
       - "5222:5222"
       - "5269:5269"

--- a/simple/docker-compose.yml
+++ b/simple/docker-compose.yml
@@ -13,6 +13,7 @@ services:
 
   xmpp1:
     image: "${OPENFIRE_IMAGE}:${OPENFIRE_TAG}"
+    pull_policy: never
     ports:
       - "5222:5222"
       - "5269:5269"


### PR DESCRIPTION
Add `pull_policy: never` to the openfire service definitions across all compose files.

The openfire image is always expected to be present locally, built and tagged before running any environment. Without this, Compose would silently attempt a registry pull if the image was missing or the image name resolved incorrectly, producing a misleading "pull access denied" error rather than a clear "image not found" failure.